### PR TITLE
Correct WGPU_BACKEND

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,9 +26,14 @@
       {
         devShell = with pkgs; mkShell rec {
 
-          nativeBuildInputs = [ pkg-config ];
+          nativeBuildInputs = [ 
+            pkg-config 
+            vulkan-tools
+          ];
           
-          LD_LIBRARY_PATH = "${lib.makeLibraryPath buildInputs}";
+          LD_LIBRARY_PATH = "${lib.makeLibraryPath buildInputs}:/run/opengl-driver/lib";
+
+          WGPU_BACKEND = "vulkan";
 
           buildInputs = [
             rustPkg


### PR DESCRIPTION
Project stopped working on 23.11, but it starts working if I do this.