### PR TITLE
Update rust gpu

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,12 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 
 [workspace.dependencies]
-spirv-std = "0.9.0"
-spirv-builder = { version = "0.9.0", default-features = false }
+
+[workspace.dependencies.spirv-std]
+git = "https://github.com/EmbarkStudios/rust-gpu"
+rev = "d0e374968a37d8a37c4f3509cd10719d384470f6"
+
+[workspace.dependencies.spirv-builder]
+git = "https://github.com/EmbarkStudios/rust-gpu"
+rev = "d0e374968a37d8a37c4f3509cd10719d384470f6"
+default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,6 @@ rev = "d0e374968a37d8a37c4f3509cd10719d384470f6"
 git = "https://github.com/EmbarkStudios/rust-gpu"
 rev = "d0e374968a37d8a37c4f3509cd10719d384470f6"
 default-features = false
+
+[profile.dev]
+package.spirv-tools-sys.opt-level = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,6 @@ authors = ["Abel <abel465@gmail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
 
-[workspace.dependencies]
-
 [workspace.dependencies.spirv-std]
 git = "https://github.com/EmbarkStudios/rust-gpu"
 rev = "d0e374968a37d8a37c4f3509cd10719d384470f6"

--- a/flake.lock
+++ b/flake.lock
@@ -8,17 +8,17 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1685168399,
-        "narHash": "sha256-QQJtv8THeKLtUtPdpqg2d638+c8yXKcwPmKx42oFqJ0=",
+        "lastModified": 1696054802,
+        "narHash": "sha256-VTON/WlYeyzFoYwwsb8KveqJJCfWEI6NtZYHcAFKBuo=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "cd56ae0389d59084fad87be375bc480e3874cade",
+        "rev": "3116ee073ab3931c78328ca126224833c95e6227",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "cd56ae0389d59084fad87be375bc480e3874cade",
+        "rev": "3116ee073ab3931c78328ca126224833c95e6227",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     fenix = {
-      url = "github:nix-community/fenix/cd56ae0389d59084fad87be375bc480e3874cade";
+      url = "github:nix-community/fenix/3116ee073ab3931c78328ca126224833c95e6227";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     flake-utils.url = "github:numtide/flake-utils";

--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,10 @@
           
           LD_LIBRARY_PATH = "${lib.makeLibraryPath buildInputs}";
 
+          # Spirv-tools crate fails to compile because the fortify
+          # feature requires the optimisation -O flag (which it does not have)
+          hardeningDisable = [ "fortify" ];
+
           buildInputs = [
             rustPkg
             xorg.libX11
@@ -37,6 +41,7 @@
             xorg.libXrandr
             xorg.libXi
             vulkan-loader
+            vulkan-tools
           ];
         };
       });

--- a/flake.nix
+++ b/flake.nix
@@ -30,10 +30,6 @@
           
           LD_LIBRARY_PATH = "${lib.makeLibraryPath buildInputs}";
 
-          # Spirv-tools crate fails to compile because the fortify
-          # feature requires the optimisation -O flag (which it does not have)
-          hardeningDisable = [ "fortify" ];
-
           buildInputs = [
             rustPkg
             xorg.libX11

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-05-27"
-components = ["rust-src", "rustc-dev", "llvm-tools-preview"]
+channel = "nightly-2023-09-30"
+components = ["rust-src", "rustc-dev", "llvm-tools"]


### PR DESCRIPTION
Updates rust-gpu to the master branch, which uses a more recent rust-nightly, which stabilizes a feature used in a recently-updated dependency.

Also adds vulkan-tools to devShell for debugging vulkan driver when WGPU `Failed to find an appropriate adapter`.