### PR TITLE
Scheme populating the grid quickly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,10 @@ authors = ["Abel <abel465@gmail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
 
+[workspace.dependencies]
+steel-core = { version = "0.6.0", path = "../../steel/crates/steel-core" }
+steel-derive = { version = "0.5.0", path = "../../steel/crates/steel-derive" }
+
 [workspace.dependencies.spirv-std]
 git = "https://github.com/EmbarkStudios/rust-gpu"
 rev = "d0e374968a37d8a37c4f3509cd10719d384470f6"
@@ -31,6 +35,7 @@ rev = "d0e374968a37d8a37c4f3509cd10719d384470f6"
 git = "https://github.com/EmbarkStudios/rust-gpu"
 rev = "d0e374968a37d8a37c4f3509cd10719d384470f6"
 default-features = false
+
 
 [profile.dev]
 package.spirv-tools-sys.opt-level = 1

--- a/flake.lock
+++ b/flake.lock
@@ -42,11 +42,13 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1705916986,
-        "narHash": "sha256-iBpfltu6QvN4xMpen6jGGEb6jOqmmVQKUrXdOJ32u8w=",
-        "path": "/nix/store/2xgpqy6dyicqnhwym6nnaysd8mzrwkr8-source",
-        "rev": "d7f206b723e42edb09d9d753020a84b3061a79d8",
-        "type": "path"
+        "lastModified": 1701330994,
+        "narHash": "sha256-cottO70nyi124wTNec4cnNG8gzGna3CjEYjKyVb6bP0=",
+        "ref": "release-23.11",
+        "rev": "d31e4e801641afaa5105fcd044d638a2b8ac546f",
+        "revCount": 552405,
+        "type": "git",
+        "url": "file:///home/liam/projects/nixpkgs"
       },
       "original": {
         "id": "nixpkgs",

--- a/runner/Cargo.toml
+++ b/runner/Cargo.toml
@@ -29,6 +29,8 @@ egui = { version = "0.23.0", features = ["extra_debug_asserts"] }
 egui-wgpu = { version = "0.23.0" }
 egui-winit = { version = "0.23.0" }
 glam = "0.24.2"
+steel-core = { workspace = true }
+steel-derive = { workspace = true }
 
 [target.'cfg(not(any(target_arch = "wasm32")))'.dependencies]
 env_logger = "0.10.0"

--- a/runner/src/shaders/sdf.scm
+++ b/runner/src/shaders/sdf.scm
@@ -1,0 +1,34 @@
+(display "Hello Scheme\n")
+
+(define (disk r)
+  (lambda (p)
+    (- (length p)
+       r)))
+
+;; pub fn torus(p: Vec2, r: Vec2) -> f32 {
+    ;; (p.length() - r.x).abs() - r.y
+; }
+;;
+
+(define (torus r)
+  (lambda (p)
+    (- (abs (- length
+               (point-x p)))
+       (point-y p))))
+
+(define sdf (torus 0.5))
+
+(define (run-sdf-iter grid i j)
+  (cond
+   ((= j NUM_Y) grid)
+   ((= i NUM_X) (run-sdf-iter grid 0 (+ j 1)))
+   (else
+    (let ([p (grid->point i j)])
+	    (grid-set grid i j (sdf p))
+	    (run-sdf-iter
+       grid
+	     (+ 1 i)
+	     j)))))
+
+(define (run-sdf)
+  (run-sdf-iter grid 0 0))

--- a/runner/src/shaders/sdf.scm
+++ b/runner/src/shaders/sdf.scm
@@ -10,9 +10,9 @@
     (~> (length p)
         (- r)
         (abs)
-        (- r))))
+        (- (* r 0.3)))))
 
-(define sdf (disk 0.3))
+(define sdf (torus 0.3))
 
 (define (run-sdf)
   (let lp ([i 0] [j 0])

--- a/runner/src/shaders/sdf.scm
+++ b/runner/src/shaders/sdf.scm
@@ -14,17 +14,12 @@
 
 (define sdf (disk 0.3))
 
-(define (run-sdf-iter grid i j)
-  (cond
-   ((= j NUM_Y) grid)
-   ((= i NUM_X) (run-sdf-iter grid 0 (+ j 1)))
-   (else
-    (let ([p (grid->point i j)])
-	    (grid-set grid i j (sdf p))
-	    (run-sdf-iter
-       grid
-	     (+ 1 i)
-	     j)))))
-
 (define (run-sdf)
-  (run-sdf-iter grid 0 0))
+  (let lp ([i 0] [j 0])
+    (cond
+     ((= j NUM_Y) grid)
+     ((= i NUM_X) (lp 0 (+ j 1)))
+     (else
+      (let ([p (grid->point i j)])
+        (grid-set grid i j (sdf p))
+        (lp (+ 1 i) j))))))

--- a/runner/src/shaders/sdf.scm
+++ b/runner/src/shaders/sdf.scm
@@ -2,21 +2,17 @@
 
 (define (disk r)
   (lambda (p)
-    (- (length p)
-       r)))
-
-;; pub fn torus(p: Vec2, r: Vec2) -> f32 {
-    ;; (p.length() - r.x).abs() - r.y
-; }
-;;
+    (~> (length p)
+        (- r))))
 
 (define (torus r)
   (lambda (p)
-    (- (abs (- length
-               (point-x p)))
-       (point-y p))))
+    (~> (length p)
+        (- r)
+        (abs)
+        (- r))))
 
-(define sdf (torus 0.5))
+(define sdf (disk 0.3))
 
 (define (run-sdf-iter grid i j)
   (cond

--- a/shaders/shared/src/sdf_2d/grid.rs
+++ b/shaders/shared/src/sdf_2d/grid.rs
@@ -3,10 +3,10 @@ use spirv_std::glam::{vec2, Vec2};
 use spirv_std::num_traits::Float;
 
 const SMOOTH_PADDING: usize = 2;
-const BASE: usize = 64 - SMOOTH_PADDING;
+pub const BASE: usize = 64 - SMOOTH_PADDING;
 const AR: usize = 3;
-const NUM_Y: usize = BASE + SMOOTH_PADDING;
-const NUM_X: usize = BASE * AR + SMOOTH_PADDING;
+pub const NUM_Y: usize = BASE + SMOOTH_PADDING;
+pub const NUM_X: usize = BASE * AR + SMOOTH_PADDING;
 const HALF_CELL_SIZE: f32 = 0.5 / BASE as f32;
 
 pub struct SdfGrid {


### PR DESCRIPTION
It expects the steel repository two directories up. This needs to be changed.

https://github.com/mattwparas/steel

Pretty cool to see it being very quick.

Some ideas:

- Code generate rust "postfix notation" (automatically detect this can be done at runtime?)
- Code generate stack machine to run on GPU
- Wrap SDF functions